### PR TITLE
Added a missing ctypedef.

### DIFF
--- a/glew_pxd.py
+++ b/glew_pxd.py
@@ -140,9 +140,11 @@ cdef extern from "include_glew.h":
     ctypedef unsigned int GLhandleARB
     ctypedef ptrdiff_t GLintptrARB
     ctypedef ptrdiff_t GLsizeiptrARB
+    ctypedef void* GLeglClientBufferEXT
     ctypedef unsigned short GLhalf
     ctypedef GLintptr GLvdpauSurfaceNV
     ctypedef long GLVULKANPROCNV
+    
 
     ctypedef void (__stdcall *GLDEBUGPROCAMD)(GLuint id, GLenum category, GLenum severity, GLsizei length, GLchar *message, GLvoid *userParam)
     ctypedef void (__stdcall *GLDEBUGPROCARB)(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar *message, GLvoid *userParam)


### PR DESCRIPTION
When installing pyglui via 'pip3 install git+https://github.com/pupil-labs/pyglui' on Mac OSX 10.12.6 with glew 2.1.0, the following error was reported: 

"pyglui/cygl/glew.pxd:8674:85: 'GLeglClientBufferEXT' is not a type identifier"

Have added the corresponding ctypedef to glew_pxd.py. This makes the installation go through.